### PR TITLE
XMLHttpRequest credentials support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,13 @@ function applyRequestHeaders(req, headers) {
   }
 }
 
-const upload = (url, {file, headers, responseType = 'json', onProgress} = {}) =>
+const upload = (url, {file, headers, responseType = 'json', credentials = false, onProgress} = {}) =>
   new Promise((resolve, reject) => {
     const data = new FormData();
     data.append('file', file);
     const req = new XMLHttpRequest();
     req.open('POST', url, true);
+    req.withCredentials = credentials;
     req.responseType = responseType;
     applyRequestHeaders(req, headers);
     req.addEventListener('load', () => {
@@ -32,10 +33,11 @@ const upload = (url, {file, headers, responseType = 'json', onProgress} = {}) =>
     req.send(data);
   });
 
-const download = (url, {headers, responseType = 'blob', onProgress} = {}) =>
+const download = (url, {headers, responseType = 'blob', credentials = false, onProgress} = {}) =>
   new Promise((resolve, reject) => {
     const req = new XMLHttpRequest();
     req.open('GET', url, true);
+    req.withCredentials = credentials;
     req.responseType = responseType;
     applyRequestHeaders(req, headers);
     req.addEventListener('load', () => {

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -40,6 +40,7 @@ describe('download', () => {
       })
       .catch(done);
     expect(requests[0].responseType).toBe('blob');
+    expect(requests[0].withCredentials).toBe(false);
     expect(requests[0].requestHeaders).toEqual({});
     expect(requests[0].requestBody).toBe(null);
     expect(requests[0].url).toBe(`${host}/files/foo.png`);
@@ -56,6 +57,7 @@ describe('download', () => {
       })
       .catch(done);
     expect(requests[0].responseType).toBe('blob');
+    expect(requests[0].withCredentials).toBe(false);
     expect(requests[0].requestHeaders).toEqual({});
     expect(requests[0].requestBody).toBe(null);
     // expect(onProgress).toHaveBeenCalled(); // @TODO report issue to jsdom
@@ -72,8 +74,24 @@ describe('download', () => {
       })
       .catch(done);
     expect(requests[0].responseType).toBe('blob');
+    expect(requests[0].withCredentials).toBe(false);
     expect(requests[0].requestBody).toBe(null);
     expect(requests[0].requestHeaders).toEqual({'X-Foo': 'bar'});
+    expect(requests[0].url).toBe(`${host}/files/foo.png`);
+    requests[0].responseType = 'text';
+    requests[0].respond(200, {'Content-Type': 'application/json'}, JSON.stringify(body));
+  });
+  it('should correctly support credentials', (done) => {
+    const body = {ok: true};
+    download(`${host}/files/foo.png`, {credentials: true})
+      .then(res => {
+        expect(res).toEqual(JSON.stringify(body));
+        done();
+      })
+      .catch(done);
+    expect(requests[0].responseType).toBe('blob');
+    expect(requests[0].withCredentials).toBe(true);
+    expect(requests[0].requestBody).toBe(null);
     expect(requests[0].url).toBe(`${host}/files/foo.png`);
     requests[0].responseType = 'text';
     requests[0].respond(200, {'Content-Type': 'application/json'}, JSON.stringify(body));
@@ -105,6 +123,7 @@ describe('upload', () => {
       })
       .catch(done);
     expect(requests[0].responseType).toBe('json');
+    expect(requests[0].withCredentials).toBe(false);
     expect(requests[0].requestHeaders).toEqual({});
     expect(requests[0].url).toBe(`${host}/files`);
     requests[0].respond(200, {'Content-Type': 'application/json'}, JSON.stringify(body));
@@ -121,6 +140,7 @@ describe('upload', () => {
       })
       .catch(done);
     expect(requests[0].responseType).toBe('json');
+    expect(requests[0].withCredentials).toBe(false);
     expect(requests[0].requestHeaders).toEqual({});
     // expect(onProgress).toHaveBeenCalled(); // @TODO report issue to jsdom
     expect(requests[0].url).toBe(`${host}/files`);
@@ -137,7 +157,23 @@ describe('upload', () => {
       })
       .catch(done);
     expect(requests[0].responseType).toBe('json');
+    expect(requests[0].withCredentials).toBe(false);
     expect(requests[0].requestHeaders).toEqual({'X-Foo': 'bar'});
+    expect(requests[0].url).toBe(`${host}/files`);
+    requests[0].respond(200, {'Content-Type': 'application/json'}, JSON.stringify(body));
+  });
+  it('should correctly support custom headers', (done) => {
+    const body = {ok: true};
+    const blob = new Blob(['foobar']);
+    const file = new File([blob], 'rM8RrRE.jpg', {size: blob.size, type: blob.type});
+    upload(`${host}/files`, {file, credentials: true})
+      .then(res => {
+        expect(res).toEqual(body);
+        done();
+      })
+      .catch(done);
+    expect(requests[0].responseType).toBe('json');
+    expect(requests[0].withCredentials).toBe(true);
     expect(requests[0].url).toBe(`${host}/files`);
     requests[0].respond(200, {'Content-Type': 'application/json'}, JSON.stringify(body));
   });


### PR DESCRIPTION
Add a credentials option for download and upload functions. By default it's set to false.
